### PR TITLE
fix: ULONG_LONG_MAX is obsolete

### DIFF
--- a/tests/+_test.cpp
+++ b/tests/+_test.cpp
@@ -49,7 +49,7 @@ int main(int ac, char ** av)
 	TEST(24, print(" %+d ", LONG_MIN));
 	TEST(25, print(" %+d ", UINT_MAX));
 	TEST(26, print(" %+d ", ULONG_MAX));
-	TEST(27, print(" %+d ", ULONG_LONG_MAX));
+	TEST(27, print(" %+d ", ULLONG_MAX));
 	TEST(28, print(" %+d %+d %+d %+d %+d %+d %+d", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(29, 56, cout << endl << FG_LGRAY << "subcategory: i" << RESET_ALL << endl;)
 	TEST(29, print(" %+i ", 0));
@@ -79,7 +79,7 @@ int main(int ac, char ** av)
 	TEST(52, print(" %+i ", LONG_MIN));
 	TEST(53, print(" %+i ", UINT_MAX));
 	TEST(54, print(" %+i ", ULONG_MAX));
-	TEST(55, print(" %+i ", ULONG_LONG_MAX));
+	TEST(55, print(" %+i ", ULLONG_MAX));
 	TEST(56, print(" %+i %+i %+i %+i %+i %+i %+i", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);

--- a/tests/0_test.cpp
+++ b/tests/0_test.cpp
@@ -49,7 +49,7 @@ int main(int ac, char ** av)
 	TEST(24, print(" %012d ", LONG_MIN));
 	TEST(25, print(" %013d ", UINT_MAX));
 	TEST(26, print(" %014d ", ULONG_MAX));
-	TEST(27, print(" %015d ", ULONG_LONG_MAX));
+	TEST(27, print(" %015d ", ULLONG_MAX));
 	TEST(28, print(" %09d %010d %011d %012d %013d %014d %015d", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(29, 56, cout << endl << FG_LGRAY << "subcategory: i" << RESET_ALL << endl;)
 	TEST(29, print(" %01i ", 0));
@@ -79,7 +79,7 @@ int main(int ac, char ** av)
 	TEST(52, print(" %012i ", LONG_MIN));
 	TEST(53, print(" %013i ", UINT_MAX));
 	TEST(54, print(" %014i ", ULONG_MAX));
-	TEST(55, print(" %015i ", ULONG_LONG_MAX));
+	TEST(55, print(" %015i ", ULLONG_MAX));
 	TEST(56, print(" %09i %010i %011i %012i %013i %014i %015i", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(57, 85, cout << endl << FG_LGRAY << "subcategory: u" << RESET_ALL << endl;)
 	TEST(57, print(" %01u ", 0));
@@ -109,7 +109,7 @@ int main(int ac, char ** av)
 	TEST(81, print(" %012u ", LONG_MIN));
 	TEST(82, print(" %013u ", UINT_MAX));
 	TEST(83, print(" %014u ", ULONG_MAX));
-	TEST(84, print(" %015u ", ULONG_LONG_MAX));
+	TEST(84, print(" %015u ", ULLONG_MAX));
 	TEST(85, print(" %09u %010u %011u %012u %013u %014u %015u", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(86, 114, cout << endl << FG_LGRAY << "subcategory: x" << RESET_ALL << endl;)
 	TEST(86, print(" %01x ", 0));
@@ -139,7 +139,7 @@ int main(int ac, char ** av)
 	TEST(110, print(" %012x ", LONG_MIN));
 	TEST(111, print(" %013x ", UINT_MAX));
 	TEST(112, print(" %014x ", ULONG_MAX));
-	TEST(113, print(" %015x ", ULONG_LONG_MAX));
+	TEST(113, print(" %015x ", ULLONG_MAX));
 	TEST(114, print(" %09x %010x %011x %012x %013x %014x %015x", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(115, 143, cout << endl << FG_LGRAY << "subcategory: X" << RESET_ALL << endl;)
 	TEST(115, print(" %01X ", 0));
@@ -169,7 +169,7 @@ int main(int ac, char ** av)
 	TEST(139, print(" %012X ", LONG_MIN));
 	TEST(140, print(" %013X ", UINT_MAX));
 	TEST(141, print(" %014X ", ULONG_MAX));
-	TEST(142, print(" %015X ", ULONG_LONG_MAX));
+	TEST(142, print(" %015X ", ULLONG_MAX));
 	TEST(143, print(" %09X %010X %011X %012X %013X %014X %015X", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);

--- a/tests/d_test.cpp
+++ b/tests/d_test.cpp
@@ -50,7 +50,7 @@ int main(int ac, char ** av)
 	TEST(25, print(" %d ", LONG_MIN));
 	TEST(26, print(" %d ", UINT_MAX));
 	TEST(27, print(" %d ", ULONG_MAX));
-	TEST(28, print(" %d ", ULONG_LONG_MAX));
+	TEST(28, print(" %d ", ULLONG_MAX));
 	TEST(29, print(" %d %d %d %d %d %d %d", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);

--- a/tests/dot_test.cpp
+++ b/tests/dot_test.cpp
@@ -60,7 +60,7 @@ int main(int ac, char ** av)
 	TEST(34, print(" %.11d ", LONG_MIN));
 	TEST(35, print(" %.12d ", UINT_MAX));
 	TEST(36, print(" %.13d ", ULONG_MAX));
-	TEST(37, print(" %.14d ", ULONG_LONG_MAX));
+	TEST(37, print(" %.14d ", ULLONG_MAX));
 	TEST(38, print(" %.8d %.9d %.10d %.11d %.12d %.13d %.14d", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(39, 67, cout << endl << FG_LGRAY << "subcategory: i" << RESET_ALL << endl;)
 	TEST(39, print(" %.1i ", 0));
@@ -90,7 +90,7 @@ int main(int ac, char ** av)
 	TEST(63, print(" %.11i ", LONG_MIN));
 	TEST(64, print(" %.12i ", UINT_MAX));
 	TEST(65, print(" %.13i ", ULONG_MAX));
-	TEST(66, print(" %.14i ", ULONG_LONG_MAX));
+	TEST(66, print(" %.14i ", ULLONG_MAX));
 	TEST(67, print(" %.8i %.9i %.10i %.11i %.12i %.13i %.14i", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(68, 96, cout << endl << FG_LGRAY << "subcategory: u" << RESET_ALL << endl;)
 	TEST(68, print(" %.1u ", 0));
@@ -120,7 +120,7 @@ int main(int ac, char ** av)
 	TEST(92, print(" %.11u ", LONG_MIN));
 	TEST(93, print(" %.12u ", UINT_MAX));
 	TEST(94, print(" %.13u ", ULONG_MAX));
-	TEST(95, print(" %.14u ", ULONG_LONG_MAX));
+	TEST(95, print(" %.14u ", ULLONG_MAX));
 	TEST(96, print(" %.8u %.9u %.10u %.11u %.12u %.13u %.14u", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(97, 125, cout << endl << FG_LGRAY << "subcategory: x" << RESET_ALL << endl;)
 	TEST(97, print(" %.1x ", 0));
@@ -150,7 +150,7 @@ int main(int ac, char ** av)
 	TEST(121, print(" %.11x ", LONG_MIN));
 	TEST(122, print(" %.12x ", UINT_MAX));
 	TEST(123, print(" %.13x ", ULONG_MAX));
-	TEST(124, print(" %.14x ", ULONG_LONG_MAX));
+	TEST(124, print(" %.14x ", ULLONG_MAX));
 	TEST(125, print(" %.8x %.9x %.10x %.11x %.12x %.13x %.14x", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(126, 154, cout << endl << FG_LGRAY << "subcategory: X" << RESET_ALL << endl;)
 	TEST(126, print(" %.1X ", 0));
@@ -180,7 +180,7 @@ int main(int ac, char ** av)
 	TEST(150, print(" %.11X ", LONG_MIN));
 	TEST(151, print(" %.12X ", UINT_MAX));
 	TEST(152, print(" %.13X ", ULONG_MAX));
-	TEST(153, print(" %.14X ", ULONG_LONG_MAX));
+	TEST(153, print(" %.14X ", ULLONG_MAX));
 	TEST(154, print(" %.8X %.9X %.10X %.11X %.12X %.13X %.14X", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);

--- a/tests/i_test.cpp
+++ b/tests/i_test.cpp
@@ -50,7 +50,7 @@ int main(int ac, char ** av)
 	TEST(25, print(" %i ", LONG_MIN));
 	TEST(26, print(" %i ", UINT_MAX));
 	TEST(27, print(" %i ", ULONG_MAX));
-	TEST(28, print(" %i ", ULONG_LONG_MAX));
+	TEST(28, print(" %i ", ULLONG_MAX));
 	TEST(29, print(" %i %i %i %i %i %i %i", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);

--- a/tests/minus_test.cpp
+++ b/tests/minus_test.cpp
@@ -80,7 +80,7 @@ int main(int ac, char ** av)
 	TEST(54, print(" %-12d ", LONG_MIN));
 	TEST(55, print(" %-13d ", UINT_MAX));
 	TEST(56, print(" %-14d ", ULONG_MAX));
-	TEST(57, print(" %-15d ", ULONG_LONG_MAX));
+	TEST(57, print(" %-15d ", ULLONG_MAX));
 	TEST(58, print(" %-9d %-10d %-11d %-12d %-13d %-14d %-15d", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(59, 86, cout << endl << FG_LGRAY << "subcategory: i" << RESET_ALL << endl;)
 	TEST(59, print(" %-1i ", 0));
@@ -110,7 +110,7 @@ int main(int ac, char ** av)
 	TEST(82, print(" %-12i ", LONG_MIN));
 	TEST(83, print(" %-13i ", UINT_MAX));
 	TEST(84, print(" %-14i ", ULONG_MAX));
-	TEST(85, print(" %-15i ", ULONG_LONG_MAX));
+	TEST(85, print(" %-15i ", ULLONG_MAX));
 	TEST(86, print(" %-9i %-10i %-11i %-12i %-13i %-14i %-15i", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(87, 115, cout << endl << FG_LGRAY << "subcategory: u" << RESET_ALL << endl;)
 	TEST(87, print(" %-1u ", 0));
@@ -140,7 +140,7 @@ int main(int ac, char ** av)
 	TEST(111, print(" %-12u ", LONG_MIN));
 	TEST(112, print(" %-13u ", UINT_MAX));
 	TEST(113, print(" %-14u ", ULONG_MAX));
-	TEST(114, print(" %-15u ", ULONG_LONG_MAX));
+	TEST(114, print(" %-15u ", ULLONG_MAX));
 	TEST(115, print(" %-9u %-10u %-11u %-12u %-13u %-14u %-15u", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(116, 144, cout << endl << FG_LGRAY << "subcategory: x" << RESET_ALL << endl;)
 	TEST(116, print(" %-1x ", 0));
@@ -170,7 +170,7 @@ int main(int ac, char ** av)
 	TEST(140, print(" %-12x ", LONG_MIN));
 	TEST(141, print(" %-13x ", UINT_MAX));
 	TEST(142, print(" %-14x ", ULONG_MAX));
-	TEST(143, print(" %-15x ", ULONG_LONG_MAX));
+	TEST(143, print(" %-15x ", ULLONG_MAX));
 	TEST(144, print(" %-9x %-10x %-11x %-12x %-13x %-14x %-15x", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(145, 173, cout << endl << FG_LGRAY << "subcategory: X" << RESET_ALL << endl;)
 	TEST(145, print(" %-1X ", 0));
@@ -200,7 +200,7 @@ int main(int ac, char ** av)
 	TEST(169, print(" %-12X ", LONG_MIN));
 	TEST(170, print(" %-13X ", UINT_MAX));
 	TEST(171, print(" %-14X ", ULONG_MAX));
-	TEST(172, print(" %-15X ", ULONG_LONG_MAX));
+	TEST(172, print(" %-15X ", ULLONG_MAX));
 	TEST(173, print(" %-9X %-10X %-11X %-12X %-13X %-14X %-15X", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);

--- a/tests/sharp_test.cpp
+++ b/tests/sharp_test.cpp
@@ -50,7 +50,7 @@ int main(int ac, char ** av)
 	TEST(25, print(" %#x ", LONG_MIN));
 	TEST(26, print(" %#x ", UINT_MAX));
 	TEST(27, print(" %#x ", ULONG_MAX));
-	TEST(28, print(" %#x ", ULONG_LONG_MAX));
+	TEST(28, print(" %#x ", ULLONG_MAX));
 	TEST(29, print(" %#x %#x %#x %#x %#x %#x %#x", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	TEST(30, print(" %#x%#x ", INT_MAX, INT_MIN));
 	SUBCATEGORY(31, 32, cout << endl << FG_LGRAY << "subcategory: X" << RESET_ALL << endl;)
@@ -81,7 +81,7 @@ int main(int ac, char ** av)
 	TEST(55, print(" %#X ", LONG_MIN));
 	TEST(56, print(" %#X ", UINT_MAX));
 	TEST(57, print(" %#X ", ULONG_MAX));
-	TEST(58, print(" %#X ", ULONG_LONG_MAX));
+	TEST(58, print(" %#X ", ULLONG_MAX));
 	TEST(59, print(" %#X %#X %#X %#X %#X %#X %#X", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);

--- a/tests/space_test.cpp
+++ b/tests/space_test.cpp
@@ -60,7 +60,7 @@ int main(int ac, char ** av)
 	TEST(34, print(" % d ", LONG_MIN));
 	TEST(35, print(" % d ", UINT_MAX));
 	TEST(36, print(" % d ", ULONG_MAX));
-	TEST(37, print(" % d ", ULONG_LONG_MAX));
+	TEST(37, print(" % d ", ULLONG_MAX));
 	TEST(38, print(" % d % d % d % d % d % d % d", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	SUBCATEGORY(39, 67, cout << endl << FG_LGRAY << "subcategory: i" << RESET_ALL << endl;)
 	TEST(39, print(" % i ", 0));
@@ -90,7 +90,7 @@ int main(int ac, char ** av)
 	TEST(63, print(" % i ", LONG_MIN));
 	TEST(64, print(" % i ", UINT_MAX));
 	TEST(65, print(" % i ", ULONG_MAX));
-	TEST(66, print(" % i ", ULONG_LONG_MAX));
+	TEST(66, print(" % i ", ULLONG_MAX));
 	TEST(67, print(" % i % i % i % i % i % i % i", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);

--- a/tests/u_test.cpp
+++ b/tests/u_test.cpp
@@ -50,7 +50,7 @@ int main(int ac, char ** av)
 	TEST(25, print(" %u ", LONG_MIN));
 	TEST(26, print(" %u ", UINT_MAX));
 	TEST(27, print(" %u ", ULONG_MAX));
-	TEST(28, print(" %u ", ULONG_LONG_MAX));
+	TEST(28, print(" %u ", ULLONG_MAX));
 	TEST(29, print(" %u %u %u %u %u %u %u", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);

--- a/tests/upperx_test.cpp
+++ b/tests/upperx_test.cpp
@@ -50,7 +50,7 @@ int main(int ac, char ** av)
 	TEST(25, print(" %X ", LONG_MIN));
 	TEST(26, print(" %X ", UINT_MAX));
 	TEST(27, print(" %X ", ULONG_MAX));
-	TEST(28, print(" %X ", ULONG_LONG_MAX));
+	TEST(28, print(" %X ", ULLONG_MAX));
 	TEST(29, print(" %X %X %X %X %X %X %X", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);

--- a/tests/x_test.cpp
+++ b/tests/x_test.cpp
@@ -50,7 +50,7 @@ int main(int ac, char ** av)
 	TEST(25, print(" %x ", LONG_MIN));
 	TEST(26, print(" %x ", UINT_MAX));
 	TEST(27, print(" %x ", ULONG_MAX));
-	TEST(28, print(" %x ", ULONG_LONG_MAX));
+	TEST(28, print(" %x ", ULLONG_MAX));
 	TEST(29, print(" %x %x %x %x %x %x %x", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
 	cout << ENDL;
 	return (0);


### PR DESCRIPTION
ULONG_LONG_MAX is obsolete and it doesn't work on Guacamole. I'm changing it for ULLONG_MAX.
```
LONG_LONG_MIN
LONG_LONG_MAX
ULONG_LONG_MAX

    These are obsolete names for LLONG_MIN, LLONG_MAX, and ULLONG_MAX. They are only available if _GNU_SOURCE is defined (see Feature Test Macros). In GCC versions prior to 3.0, these were the only names available.
```
**Link:** [https://www.gnu.org/software/libc/manual/html_node/Range-of-Type.html](url)
**uname -a:** Darwin 18.6.0 Darwin Kernel Version 18.6.0: Thu Apr 25 23:16:27 PDT 2019; root:xnu-4903.261.4~2/RELEASE_X86_64 x86_64