### PR TITLE
Added tests to check for faulty logic during conversion to hexadecimal

### DIFF
--- a/tests/x_test.cpp
+++ b/tests/x_test.cpp
@@ -52,6 +52,8 @@ int main(int ac, char ** av)
 	TEST(27, print(" %x ", ULONG_MAX));
 	TEST(28, print(" %x ", 9223372036854775807LL));
 	TEST(29, print(" %x %x %x %x %x %x %x", INT_MAX, INT_MIN, LONG_MAX, LONG_MIN, ULONG_MAX, 0, -42));
+	TEST(30, print(" %x ", 42));
+	TEST(31, print(" %x ", -42));
 	cout << ENDL;
 	return (0);
 }

--- a/tests/x_test.cpp
+++ b/tests/x_test.cpp
@@ -8,7 +8,7 @@ extern "C"
 #include "sigsegv.hpp"
 #include "check.hpp"
 #include "print.hpp"
-#define TEST_LIMIT 29
+#define TEST_LIMIT 31
 
 int iTest = 1;
 int testNumber;


### PR DESCRIPTION
This pull request was made to add two tests in order to check for a specific edge case that I encountered while running the tests.

In the function where I convert to hexadecimal, I have an if condition to check if the remainder is less than 10 (and therefore 0-9 in hexadecimal) or bigger than 9 (and therefore A-F in hexadecimal):

`	if (hex % 16 <= 10)
		ft_putnbr(hex % 16, counter);
	else
		*counter += write(1, &alpha[hex % 16 - 10], 1);`

I actually wrote <= (line 1), which is wrong and can be seen trying to convert the decimal 42 to hexadecimal. The result shown is 210 and not 2A.

I added two test cases with 42 and -42.
I run the tests with the faulty code and the positive case flags the error correctly.